### PR TITLE
Create initial calc endpoint

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic==1.10.4
 fastapi-restful==0.4.3
 httpx==0.23.3
 pytest==7.2.0
+httpx==0.23.3

--- a/backend/salary_calc_fastapi/app.py
+++ b/backend/salary_calc_fastapi/app.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi_restful import Api
 from fastapi.middleware.cors import CORSMiddleware
-from salary_calc_fastapi.endpoints.hello_world import HelloWorld
+from salary_calc_fastapi.endpoints.salary_calculation import SalaryCalculation
 
 
 def create_app():
@@ -14,7 +14,7 @@ def create_app():
     )
 
     api = Api(app)
-    api.add_resource(HelloWorld(), "/helloworld")
+    api.add_resource(SalaryCalculation(), "/salary")
     return app
 
 

--- a/backend/salary_calc_fastapi/endpoints/salary_calculation.py
+++ b/backend/salary_calc_fastapi/endpoints/salary_calculation.py
@@ -1,7 +1,7 @@
 from fastapi_restful import Resource
 
 
-class HelloWorld(Resource):
+class SalaryCalculation(Resource):
 
     def get(self):
         return {"hello": "world"}

--- a/backend/salary_calc_fastapi/endpoints/salary_calculation.py
+++ b/backend/salary_calc_fastapi/endpoints/salary_calculation.py
@@ -1,7 +1,20 @@
 from fastapi_restful import Resource
+from fastapi import Request
+from salary_calc_fastapi.models.salary import Salary
+from pydantic import BaseModel
+
+
+class SalaryRequest(BaseModel):
+    reference_salary: float
 
 
 class SalaryCalculation(Resource):
-
     def get(self):
         return {"hello": "world"}
+
+    def post(self, example: SalaryRequest):
+        salary = Salary(reference_salary=example.reference_salary)
+        return {
+            "Original salary": example.reference_salary,
+            "Net salary": salary.get_net(),
+        }

--- a/backend/salary_calc_fastapi/tests/endpoints/test_salary_calculation.py
+++ b/backend/salary_calc_fastapi/tests/endpoints/test_salary_calculation.py
@@ -9,7 +9,7 @@ class TestHellowWorldEndpoint(TestCase):
         self.client = TestClient(app)
 
     def test_successful_response(self):
-        response = self.client.get('/helloworld')
+        response = self.client.get('/salary')
         expected_response = {"hello": "world"}
 
         self.assertEqual(expected_response, response.json())

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -24,4 +24,5 @@ server {
     add_header Access-Control-Max-Age 3600;
     add_header Access-Control-Expose-Headers Content-Length;
     add_header Access-Control-Allow-Headers Range;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
 }

--- a/frontend/src/hello_world.ts
+++ b/frontend/src/hello_world.ts
@@ -1,4 +1,5 @@
-fetch("http://localhost:5000/helloworld")
+console.log("Hi!");
+fetch("http://localhost:5000/salary")
   .then(function (response) {
     return response.json();
   })

--- a/frontend/src/hello_world.ts
+++ b/frontend/src/hello_world.ts
@@ -1,5 +1,14 @@
-console.log("Hi!");
-fetch("http://localhost:5000/salary")
+fetch("http://localhost:5000/salary", {
+  method: "POST",
+
+  body: JSON.stringify({
+    reference_salary: 47000,
+  }),
+
+  headers: {
+    "Content-type": "application/json; charset=UTF-8",
+  },
+})
   .then(function (response) {
     return response.json();
   })


### PR DESCRIPTION
Added initial `/salary` endpoint, and a minimal `POST` retrieval using the frontend to calculate net salary from reference salary.